### PR TITLE
Remove any fractions of a cent before sending to stripe

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -51,6 +51,8 @@ redirect_from:
     amount = Math.round((amount + 0.00001) * 100) / 100;
     // Back to cents
     amount = amount * 100
+    // Trim off any fractions of a cents
+    amount = Math.trunc(amount);
     document.getElementById('donationButton').textContent = "Make $"+(amount/100)+" donation";
   }
   donationAmount.addEventListener('keyup', updateAmount);


### PR DESCRIPTION
This was a weird one. For some reason, donations for $2500 plus fees ended up having .00000000003 of a cent, as well. I wasn't able to find any other numbers that would do this, though I didn't try every number. This just bluntly removes any fractions of a cent after converting from dollars to cents, so that shouldn't happen any more.